### PR TITLE
Mock the api with MockRetrofit

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,6 +22,16 @@ android {
         }
     }
 
+    flavorDimensions "version"
+    productFlavors {
+        prod {
+            buildConfigField "boolean", "isMockDataEnabled", "false"
+        }
+        mock {
+            buildConfigField "boolean", "isMockDataEnabled", "true"
+        }
+    }
+
     dataBinding {
         enabled true
     }
@@ -83,6 +93,7 @@ dependencies {
     // Retrofit
     implementation "com.squareup.retrofit2:retrofit:$retrofit_version"
     implementation "com.squareup.retrofit2:converter-gson:$retrofit_version"
+    implementation "com.squareup.retrofit2:retrofit-mock:$retrofit_version"
     implementation 'com.jakewharton.retrofit:retrofit2-kotlin-coroutines-adapter:0.9.2'
 
     testImplementation 'junit:junit:4.12'

--- a/app/src/main/java/app/vdh/org/vdhapp/core/consts/ApiConst.kt
+++ b/app/src/main/java/app/vdh/org/vdhapp/core/consts/ApiConst.kt
@@ -1,0 +1,5 @@
+package app.vdh.org.vdhapp.core.consts
+
+object ApiConst {
+    const val BASE_URL = "https://ohp6vrr7xd.execute-api.ca-central-1.amazonaws.com/dev/api/v1/"
+}

--- a/app/src/main/java/app/vdh/org/vdhapp/core/di/DiModules.kt
+++ b/app/src/main/java/app/vdh/org/vdhapp/core/di/DiModules.kt
@@ -1,12 +1,14 @@
 package app.vdh.org.vdhapp.core.di
 
+import app.vdh.org.vdhapp.BuildConfig
+import app.vdh.org.vdhapp.core.consts.ApiConst.BASE_URL
 import app.vdh.org.vdhapp.feature.report.data.common.local.AppDatabase
-import app.vdh.org.vdhapp.feature.report.data.common.remote.ApiRetrofitClient
+import app.vdh.org.vdhapp.feature.report.data.common.remote.RetrofitClient
 import app.vdh.org.vdhapp.feature.report.domain.common.repository.ReportRepository
 import app.vdh.org.vdhapp.feature.report.data.common.repository.ReportRepositoryImpl
 import app.vdh.org.vdhapp.feature.report.data.common.remote.ObservationApiClient
 import app.vdh.org.vdhapp.feature.report.data.common.remote.ObservationApiClientImpl
-import app.vdh.org.vdhapp.feature.report.data.common.remote.ObservationApiClientImpl.Companion.BASE_URL
+import app.vdh.org.vdhapp.feature.report.data.common.remote.mock.RetrofitMockClient
 import app.vdh.org.vdhapp.feature.report.data.map.remote.BicyclePathApiClient
 import app.vdh.org.vdhapp.feature.report.data.map.remote.BicyclePathApiClientImpl
 import app.vdh.org.vdhapp.feature.report.data.map.repository.BicyclePathRepositoryImpl
@@ -25,6 +27,7 @@ import org.koin.android.viewmodel.ext.koin.viewModel
 import org.koin.dsl.module.module
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
+import retrofit2.mock.MockRetrofit
 
 val appModule = module {
 
@@ -35,13 +38,19 @@ val appModule = module {
         database.declarationDao()
     }
 
-    single<ApiRetrofitClient> {
-        Retrofit.Builder()
-                .baseUrl(BASE_URL)
-                .addConverterFactory(GsonConverterFactory.create())
-                .addCallAdapterFactory(CoroutineCallAdapterFactory())
+    single {
+        val mockRetrofit = MockRetrofit.Builder(buildBaseRetrofit())
                 .build()
-                .create(ApiRetrofitClient::class.java)
+        val delegate = mockRetrofit.create(RetrofitClient::class.java)
+        RetrofitMockClient(delegate, get() as AppDatabase)
+    }
+
+    single<RetrofitClient> {
+        if (BuildConfig.isMockDataEnabled) {
+            get() as RetrofitMockClient
+        } else {
+            buildBaseRetrofit().create(RetrofitClient::class.java)
+        }
     }
 
     single<ObservationApiClient> { ObservationApiClientImpl(get()) }
@@ -59,4 +68,12 @@ val appModule = module {
     viewModel { ReportMapViewModel(androidApplication(), get(), get()) }
     viewModel { StatusFilterViewModel(androidApplication()) }
     viewModel { HoursFilterViewModel(androidApplication()) }
+}
+
+private fun buildBaseRetrofit(): Retrofit {
+    return Retrofit.Builder()
+            .addConverterFactory(GsonConverterFactory.create())
+            .addCallAdapterFactory(CoroutineCallAdapterFactory())
+            .baseUrl(BASE_URL)
+            .build() as Retrofit
 }

--- a/app/src/main/java/app/vdh/org/vdhapp/feature/report/data/common/local/AppDatabase.kt
+++ b/app/src/main/java/app/vdh/org/vdhapp/feature/report/data/common/local/AppDatabase.kt
@@ -6,10 +6,18 @@ import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
 import android.content.Context
 import app.vdh.org.vdhapp.feature.report.data.common.local.entity.ReportEntity
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import kotlin.coroutines.CoroutineContext
 
 @Database(entities = [ReportEntity::class], version = 7, exportSchema = false)
 @TypeConverters(Converters::class)
-abstract class AppDatabase : RoomDatabase() {
+abstract class AppDatabase : RoomDatabase(), CoroutineScope {
+
+    override val coroutineContext: CoroutineContext
+        get() = Job() + Dispatchers.Default
 
     companion object {
 
@@ -19,6 +27,12 @@ abstract class AppDatabase : RoomDatabase() {
             return Room.databaseBuilder(context, AppDatabase::class.java, DATABASE_NAME)
                     .fallbackToDestructiveMigration()
                     .build()
+        }
+    }
+
+    fun clear() {
+        launch {
+            clearAllTables()
         }
     }
 

--- a/app/src/main/java/app/vdh/org/vdhapp/feature/report/data/common/remote/ObservationApiClientImpl.kt
+++ b/app/src/main/java/app/vdh/org/vdhapp/feature/report/data/common/remote/ObservationApiClientImpl.kt
@@ -2,20 +2,16 @@ package app.vdh.org.vdhapp.feature.report.data.common.remote
 
 import android.util.Log
 import app.vdh.org.vdhapp.core.helpers.CallResult
+import app.vdh.org.vdhapp.core.helpers.safeCall
 import app.vdh.org.vdhapp.feature.report.data.common.remote.dto.ObservationDto
 import app.vdh.org.vdhapp.feature.report.data.common.remote.dto.ObservationListDto
-import app.vdh.org.vdhapp.core.helpers.safeCall
 import okhttp3.ResponseBody
 
-class ObservationApiClientImpl(private val apiClient: ApiRetrofitClient) : ObservationApiClient {
-
-    companion object {
-        const val BASE_URL = "https://ohp6vrr7xd.execute-api.ca-central-1.amazonaws.com/dev/api/v1/"
-    }
+class ObservationApiClientImpl(private val client: RetrofitClient) : ObservationApiClient {
 
     override suspend fun sendObservation(observationDto: ObservationDto): CallResult<ObservationDto> {
         return safeCall({
-            val response = apiClient.postObservationAsync(observationDto).await()
+            val response = client.postObservationAsync(observationDto).await()
             val observation = response.body()
             if (response.isSuccessful && observation != null) {
                 CallResult.Success(observation)
@@ -28,7 +24,7 @@ class ObservationApiClientImpl(private val apiClient: ApiRetrofitClient) : Obser
 
     override suspend fun getObservations(): CallResult<ObservationListDto> {
         return safeCall({
-            val response = apiClient.getObservationsAsync().await()
+            val response = client.getObservationsAsync().await()
             val observationList = response.body()
             if (response.isSuccessful && observationList != null) {
                 CallResult.Success(observationList)
@@ -41,7 +37,7 @@ class ObservationApiClientImpl(private val apiClient: ApiRetrofitClient) : Obser
 
     override suspend fun removeObservation(observationId: String): CallResult<ResponseBody> {
         return safeCall({
-            val response = apiClient.deleteObservationAsync(observationId).await()
+            val response = client.deleteObservationAsync(observationId).await()
             val responseBody = response.body()
             if (response.isSuccessful && responseBody != null) {
                 CallResult.Success(responseBody)

--- a/app/src/main/java/app/vdh/org/vdhapp/feature/report/data/common/remote/RetrofitClient.kt
+++ b/app/src/main/java/app/vdh/org/vdhapp/feature/report/data/common/remote/RetrofitClient.kt
@@ -15,7 +15,7 @@ import retrofit2.http.Query
 import retrofit2.http.DELETE
 import retrofit2.http.Path
 
-interface ApiRetrofitClient {
+interface RetrofitClient {
 
     @POST("observations")
     fun postObservationAsync(@Body observation: ObservationDto): Deferred<Response<ObservationDto>>

--- a/app/src/main/java/app/vdh/org/vdhapp/feature/report/data/common/remote/mock/RetrofitMockClient.kt
+++ b/app/src/main/java/app/vdh/org/vdhapp/feature/report/data/common/remote/mock/RetrofitMockClient.kt
@@ -1,0 +1,108 @@
+package app.vdh.org.vdhapp.feature.report.data.common.remote.mock
+
+import app.vdh.org.vdhapp.feature.report.data.common.local.AppDatabase
+import app.vdh.org.vdhapp.feature.report.data.common.remote.RetrofitClient
+import app.vdh.org.vdhapp.feature.report.data.common.remote.dto.ObservationDto
+import app.vdh.org.vdhapp.feature.report.data.common.remote.dto.ObservationListDto
+import app.vdh.org.vdhapp.feature.report.data.map.remote.LatLngQueryParameter
+import app.vdh.org.vdhapp.feature.report.domain.common.model.Status
+import app.vdh.org.vdhapp.feature.report.domain.map.model.BikePathNetwork
+import app.vdh.org.vdhapp.feature.report.domain.map.model.BoundingBoxQueryParameter
+import kotlinx.coroutines.Deferred
+import okhttp3.ResponseBody
+import retrofit2.Response
+import retrofit2.mock.BehaviorDelegate
+import retrofit2.mock.Calls
+import java.io.IOException
+import java.util.Calendar
+import kotlin.math.cos
+import kotlin.math.sin
+import kotlin.math.sqrt
+import kotlin.random.Random
+
+class RetrofitMockClient(
+    private val behaviourDelegate: BehaviorDelegate<RetrofitClient>,
+    private val appDatabase: AppDatabase
+) : RetrofitClient {
+
+    companion object {
+        private val CENTER = RandomCoordinatesCenter(Pair(-73.557822, 45.522739), 300)
+        private const val MOCK_COUNT = 10
+    }
+
+    private val observations = mutableListOf<ObservationDto>()
+
+    fun generateMockData() {
+        appDatabase.clear()
+        observations.clear()
+        observations.addAll(generateMockObservations())
+    }
+
+    override fun postObservationAsync(observation: ObservationDto): Deferred<Response<ObservationDto>> {
+        observations.add(observation)
+        return behaviourDelegate
+                .returningResponse(observation)
+                .postObservationAsync(observation)
+    }
+
+    override fun getObservationsAsync(startTimeStamp: Long?, endTimestamp: Long?, sort: String?, nextToken: String?): Deferred<Response<ObservationListDto>> {
+        return behaviourDelegate
+                .returningResponse(ObservationListDto(observations, ""))
+                .getObservationsAsync(startTimeStamp, endTimestamp, sort, nextToken)
+    }
+
+    override fun deleteObservationAsync(id: String): Deferred<Response<ResponseBody>> {
+        val index = observations.indexOfLast { it.id == id }
+        if (index != -1) {
+            observations.removeAt(index)
+        }
+        return behaviourDelegate
+                .returningResponse(Response.success(id))
+                .deleteObservationAsync(id)
+    }
+
+    override fun getBicyclePathsAsync(boundingBoxQueryParameter: BoundingBoxQueryParameter?, centerLatLng: LatLngQueryParameter?, nextToken: String?, bikePathNetwork: BikePathNetwork): Deferred<Response<ResponseBody>> {
+        return behaviourDelegate
+                .returningResponse(Calls.failure<String>(IOException("")))
+                .getBicyclePathsAsync(boundingBoxQueryParameter, centerLatLng, nextToken, bikePathNetwork)
+    }
+
+    private fun generateMockObservations(): List<ObservationDto> {
+
+        val mockData = (1..MOCK_COUNT).toList().map {
+            val statusIndex = Random.nextInt(Status.values().size)
+            MockReportInfo(CENTER.getRandomCoordinates(), Status.values()[statusIndex])
+        }
+
+        val calendar = Calendar.getInstance()
+        return mockData.mapIndexed { index, mock ->
+            calendar.add(Calendar.MINUTE, index)
+            ObservationDto(
+                    id = index.toString(),
+                    timestamp = calendar.timeInMillis / 1000,
+                    position = arrayOf(mock.coordinates.first, mock.coordinates.second),
+                    deviceId = "121212121",
+                    attributes = arrayOf(mock.status.name),
+                    assets = null,
+                    comment = "test report $index"
+            )
+        }
+    }
+
+    private fun RandomCoordinatesCenter.getRandomCoordinates(): Pair<Double, Double> {
+        val radiusInDegrees = radius / 111000f
+        val u = Random.nextDouble()
+        val v = Random.nextDouble()
+        val w = radiusInDegrees * sqrt(u)
+        val t = Math.PI * v
+        val x = w * cos(t)
+        val y = w * sin(t)
+        val adjustedX = x / cos(Math.toRadians(coordinates.second))
+        val foundLongitude: Double = adjustedX + coordinates.first
+        val foundLatitude = y + coordinates.second
+        return Pair(foundLatitude, foundLongitude)
+    }
+
+    private data class MockReportInfo(val coordinates: Pair<Double, Double>, val status: Status)
+    private data class RandomCoordinatesCenter(val coordinates: Pair<Double, Double>, val radius: Int)
+}

--- a/app/src/main/java/app/vdh/org/vdhapp/feature/report/data/common/repository/ReportRepositoryImpl.kt
+++ b/app/src/main/java/app/vdh/org/vdhapp/feature/report/data/common/repository/ReportRepositoryImpl.kt
@@ -71,7 +71,8 @@ class ReportRepositoryImpl(
     }
 
     private suspend fun saveObservationList(observationListDto: ObservationListDto): CallResult<List<Long>> {
-        return CallResult.Success(reportDao.insertReportList(observationListDto.observationList.toReportEntities()))
+        val reports = observationListDto.observationList.toReportEntities()
+        return CallResult.Success(reportDao.insertReportList(reports))
     }
 
     private suspend fun savedReport(report: ReportEntity): CallResult<Long> {

--- a/app/src/main/java/app/vdh/org/vdhapp/feature/report/data/map/remote/BicyclePathApiClientImpl.kt
+++ b/app/src/main/java/app/vdh/org/vdhapp/feature/report/data/map/remote/BicyclePathApiClientImpl.kt
@@ -1,7 +1,7 @@
 package app.vdh.org.vdhapp.feature.report.data.map.remote
 
 import app.vdh.org.vdhapp.core.helpers.CallResult
-import app.vdh.org.vdhapp.feature.report.data.common.remote.ApiRetrofitClient
+import app.vdh.org.vdhapp.feature.report.data.common.remote.RetrofitClient
 import app.vdh.org.vdhapp.core.helpers.safeCall
 import app.vdh.org.vdhapp.feature.report.domain.map.model.BikePathNetwork
 import app.vdh.org.vdhapp.feature.report.domain.map.model.BoundingBoxQueryParameter
@@ -10,7 +10,7 @@ import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
 
-class BicyclePathApiClientImpl(private val apiClient: ApiRetrofitClient) : BicyclePathApiClient {
+class BicyclePathApiClientImpl(private val client: RetrofitClient) : BicyclePathApiClient {
 
     override suspend fun getBicyclePaths(boundingBoxQueryParameter: BoundingBoxQueryParameter?, centerCoordinates: LatLng?, geoJsonItems: JSONArray?, nextToken: String?, network: BikePathNetwork): CallResult<JSONObject> {
         return safeCall(call = {
@@ -19,7 +19,7 @@ class BicyclePathApiClientImpl(private val apiClient: ApiRetrofitClient) : Bicyc
             } else {
                 null
             }
-            val result = apiClient.getBicyclePathsAsync(
+            val result = client.getBicyclePathsAsync(
                     boundingBoxQueryParameter = boundingBoxQueryParameter,
                     centerLatLng = latLngQueryParameter,
                     nextToken = nextToken,

--- a/app/src/main/java/app/vdh/org/vdhapp/feature/report/presentation/common/databinding/BindingAdapter.kt
+++ b/app/src/main/java/app/vdh/org/vdhapp/feature/report/presentation/common/databinding/BindingAdapter.kt
@@ -45,14 +45,16 @@ class BindingAdapter {
         @JvmStatic
         @BindingAdapter(value = ["placeName", "placeLocation"])
         fun setPlace(mapView: MapView, placeName: String?, placeLocation: LatLng?) {
-            if (placeName != null && placeLocation != null) {
+            if (placeLocation != null) {
                 mapView.getMapAsync { googleMap ->
                     googleMap.uiSettings.setAllGesturesEnabled(false)
                     googleMap.uiSettings.isZoomControlsEnabled = true
                     googleMap.moveCamera(CameraUpdateFactory.newLatLngZoom(placeLocation, 18.0f))
 
                     val marker = MarkerOptions().position(placeLocation)
-                    marker.title(placeName)
+                    if (placeName != null) {
+                        marker.title(placeName)
+                    }
                     googleMap.addMarker(marker)
                 }
             }

--- a/app/src/main/java/app/vdh/org/vdhapp/feature/report/presentation/map/activity/ReportMapActivity.kt
+++ b/app/src/main/java/app/vdh/org/vdhapp/feature/report/presentation/map/activity/ReportMapActivity.kt
@@ -6,7 +6,6 @@ import android.content.Intent
 import android.content.SharedPreferences
 import android.content.pm.PackageManager
 import android.os.Bundle
-import android.preference.PreferenceManager
 import android.view.Menu
 import android.view.MenuItem
 import androidx.appcompat.app.AppCompatActivity
@@ -14,18 +13,19 @@ import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.Observer
+import androidx.preference.PreferenceManager
 import app.vdh.org.vdhapp.R
 import app.vdh.org.vdhapp.feature.report.presentation.reporting.activity.ReportingActivity
 import app.vdh.org.vdhapp.feature.settings.presentation.activity.SettingsActivity
 import app.vdh.org.vdhapp.core.consts.PrefConst
 import app.vdh.org.vdhapp.core.consts.PrefConst.HOURS_SORT_PREFS_KEY
 import app.vdh.org.vdhapp.core.consts.PrefConst.STATUS_SORT_PREFS_KEY
-import app.vdh.org.vdhapp.feature.report.data.common.local.entity.ReportEntity
 import app.vdh.org.vdhapp.feature.report.domain.map.model.BoundingBoxQueryParameter
 import app.vdh.org.vdhapp.feature.report.domain.common.model.Status
 import app.vdh.org.vdhapp.core.extenstion.navigateTo
 import app.vdh.org.vdhapp.core.extenstion.openBottomDialogFragment
 import app.vdh.org.vdhapp.databinding.ActivityReportMapBinding
+import app.vdh.org.vdhapp.feature.report.domain.common.model.ReportModel
 import app.vdh.org.vdhapp.feature.report.domain.map.model.BikePathNetwork
 import app.vdh.org.vdhapp.feature.report.presentation.map.action.ReportMapAction
 import app.vdh.org.vdhapp.feature.report.presentation.map.action.ReportMapFilterViewAction
@@ -122,7 +122,7 @@ class ReportMapActivity : AppCompatActivity(), OnMapReadyCallback {
             }
             map.setOnMarkerClickListener {
                 val bundle = Bundle()
-                bundle.putParcelable(ReportingActivity.REPORT_ARGS_KEY, it.tag as ReportEntity)
+                bundle.putParcelable(ReportingActivity.REPORT_ARGS_KEY, it.tag as ReportModel)
                 this.navigateTo(ReportingActivity::class.java, bundle)
                 true
             }

--- a/app/src/main/java/app/vdh/org/vdhapp/feature/settings/presentation/fragment/SettingsFragment.kt
+++ b/app/src/main/java/app/vdh/org/vdhapp/feature/settings/presentation/fragment/SettingsFragment.kt
@@ -4,13 +4,25 @@ import android.graphics.Color
 import android.graphics.drawable.ColorDrawable
 import android.os.Bundle
 import android.view.View
+import androidx.preference.Preference
+import androidx.preference.PreferenceCategory
 import androidx.preference.PreferenceFragmentCompat
+import app.vdh.org.vdhapp.BuildConfig
 import app.vdh.org.vdhapp.R
+import app.vdh.org.vdhapp.feature.report.data.common.remote.mock.RetrofitMockClient
+import org.koin.android.ext.android.inject
 
 class SettingsFragment : PreferenceFragmentCompat() {
 
+    val retrofitMockClient by inject<RetrofitMockClient>()
+
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         setPreferencesFromResource(R.xml.preferences, rootKey)
+        findPreference<PreferenceCategory>(getString(R.string.pref_key_debug_category))?.isVisible = BuildConfig.isMockDataEnabled
+        findPreference<Preference>(getString(R.string.pref_key_mock_data))?.setOnPreferenceClickListener {
+            retrofitMockClient.generateMockData()
+            true
+        }
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/app/src/main/java/app/vdh/org/vdhapp/feature/settings/presentation/preferences/TeamMemberPreference.kt
+++ b/app/src/main/java/app/vdh/org/vdhapp/feature/settings/presentation/preferences/TeamMemberPreference.kt
@@ -27,9 +27,6 @@ class TeamMemberPreference @JvmOverloads constructor(
                 context.getString(R.string.pref_key_tom) -> {
                     onBind(R.string.settings_team_tom, R.string.settings_team_tom_role, holder)
                 }
-                context.getString(R.string.pref_key_ju) -> {
-                    onBind(R.string.settings_team_julien, R.string.settings_team_julien_role, holder)
-                }
             }
         }
     }

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -3,7 +3,8 @@
     <string name="pref_key_karim">pref_key_karim</string>
     <string name="pref_key_tom">pref_key_tom</string>
     <string name="pref_key_yo">pref_key_yo</string>
-    <string name="pref_key_ju">pref_key_ju</string>
     <string name="pref_key_feedback">pref_key_feedback</string>
     <string name="pref_key_admin">pref_key_admin</string>
+    <string name="pref_key_mock_data">generate_mock_data_key</string>
+    <string name="pref_key_debug_category">pref_key_debug_category</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -58,11 +58,8 @@
     <string name="settings_team_tom">Tom</string>
     <string name="settings_team_tom_role">Super hero du design</string>
 
-    <string name="settings_team_julien">Julien</string>
-    <string name="settings_team_julien_role">Acrobate de l\'api</string>
-
     <string name="settings_team_karim">Karim</string>
-    <string name="settings_team_karim_role">Guru a deux roux</string>
+    <string name="settings_team_karim_role">Guru a une roue</string>
 
     <string name="settings_admin_title">Administration</string>
     <string name="settings_admin_subtitle">Adminstrer les rapports</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -33,14 +33,22 @@
         <app.vdh.org.vdhapp.feature.settings.presentation.preferences.TeamMemberPreference
             app:key="@string/pref_key_tom"
             android:layout="@layout/preference_team_member"/>
-        <app.vdh.org.vdhapp.feature.settings.presentation.preferences.TeamMemberPreference
-            app:key="@string/pref_key_ju"
-            android:layout="@layout/preference_team_member"/>
 
     </androidx.preference.PreferenceCategory>
 
     <app.vdh.org.vdhapp.feature.settings.presentation.preferences.TitleSubtitlePreference
         app:key="@string/pref_key_admin"
         android:layout="@layout/preference_title_subtitle" />
+
+    <androidx.preference.PreferenceCategory
+        app:title="Mock data"
+        android:key="@string/pref_key_debug_category"
+        android:layout="@layout/preference_custom_category">
+
+        <Preference
+            android:key="@string/pref_key_mock_data"
+            android:title="Generer des donnes mock"/>
+
+    </androidx.preference.PreferenceCategory>
 
 </androidx.preference.PreferenceScreen>

--- a/build.gradle
+++ b/build.gradle
@@ -4,8 +4,8 @@ buildscript {
     ext {
         support_version = '1.0.2'
         kotlin_version = '1.3.30'
-        lifecycle_version = '2.2.0-rc02'
-        room_version = '2.2.2'
+        lifecycle_version = '2.2.0'
+        room_version = '2.2.3'
         retrofit_version = '2.4.0'
         coroutine_version = '1.3.0'
         constraint_layout_version= '1.1.2'
@@ -21,7 +21,7 @@ buildscript {
         maven { url 'https://maven.fabric.io/public' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.2'
+        classpath 'com.android.tools.build:gradle:3.5.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.61"
         classpath 'io.fabric.tools:gradle:1.+'
     }


### PR DESCRIPTION
- Use MockRetrofit to mock observation endpoints 
- Create a flavor to use mock version of retrofit client
- Add a mock entry in settings only visible when we are in mock flavor 
- We can tap on this settings option to generate mock reports 