### PR TITLE
Provide map key via build.properties or ENV variable for CI

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -14,4 +14,7 @@ jobs:
       with:
         java-version: 1.8
     - name: Build with Gradle
-      run: ./gradlew build
+      run: ./gradlew assembleProdDebug
+      env:
+        MAP_KEY_CI: aaaabbbcccddd
+

--- a/.gitignore
+++ b/.gitignore
@@ -11,8 +11,4 @@
 .externalNativeBuild
 \.idea/
 *.apk
-app/release/
-app/src/debug/res/values/google_maps_api.xml
-app/src/release/res/values/google_maps_api.xml
-
 app/google-services.json

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,11 +14,25 @@ android {
         versionCode 1
         versionName "1.0.0-alpha-10"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+
     }
     buildTypes {
+
+        def hasMapKeyDebugProperty = project.hasProperty('maps.key.debug')
+        def hasMapKeyReleaseProperty = project.hasProperty('maps.key.release')
+        def mapKeyEnv = System.getenv('MAP_KEY_CI')
+
+        def mapKeyDebug = hasMapKeyDebugProperty ? project.property('maps.key.debug') : mapKeyEnv
+        def mapKeyRelease = hasMapKeyReleaseProperty? project.property('maps.key.release') : mapKeyEnv
+
+        debug {
+            manifestPlaceholders = [maps_api_key: mapKeyDebug]
+        }
+
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            manifestPlaceholders = [maps_api_key: mapKeyRelease]
         }
     }
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -37,7 +37,7 @@
 
         <meta-data
             android:name="com.google.android.geo.API_KEY"
-            android:value="@string/google_maps_key" />
+            android:value="${maps_api_key}" />
 
         <provider
             android:name="androidx.core.content.FileProvider"

--- a/app/src/main/java/app/vdh/org/vdhapp/feature/report/data/common/remote/mock/RetrofitMockClient.kt
+++ b/app/src/main/java/app/vdh/org/vdhapp/feature/report/data/common/remote/mock/RetrofitMockClient.kt
@@ -14,7 +14,8 @@ import retrofit2.Response
 import retrofit2.mock.BehaviorDelegate
 import retrofit2.mock.Calls
 import java.io.IOException
-import java.util.*
+import java.util.UUID
+import java.util.Calendar
 import kotlin.math.cos
 import kotlin.math.sin
 import kotlin.math.sqrt


### PR DESCRIPTION
- CI is falling because the map key is missing 
- The map key is now provided by user home located gradle.properties
- The Action CI take it from Env variable
- Use `manifestPlaceholders` to get key from gradle to manifest
