### PR TITLE
Add api endpoint, dao and screen to prepare moderation feature

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,7 +23,7 @@ android {
         def mapKeyEnv = System.getenv('MAP_KEY_CI')
 
         def mapKeyDebug = hasMapKeyDebugProperty ? project.property('maps.key.debug') : mapKeyEnv
-        def mapKeyRelease = hasMapKeyReleaseProperty? project.property('maps.key.release') : mapKeyEnv
+        def mapKeyRelease = hasMapKeyReleaseProperty ? project.property('maps.key.release') : mapKeyEnv
 
         debug {
             manifestPlaceholders = [maps_api_key: mapKeyDebug]

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,13 +27,11 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-
         <activity
             android:name=".feature.report.presentation.reporting.activity.ReportingActivity"
-            android:label="@string/app_name"/>
-
-        <activity
-            android:name=".feature.settings.presentation.activity.SettingsActivity"/>
+            android:label="@string/app_name" />
+        <activity android:name=".feature.settings.presentation.activity.SettingsActivity" />
+        <activity android:name=".feature.report.presentation.moderation.activity.ReportModerationActivity"/>
 
         <meta-data
             android:name="com.google.android.geo.API_KEY"

--- a/app/src/main/java/app/vdh/org/vdhapp/core/consts/ApiConst.kt
+++ b/app/src/main/java/app/vdh/org/vdhapp/core/consts/ApiConst.kt
@@ -2,4 +2,8 @@ package app.vdh.org.vdhapp.core.consts
 
 object ApiConst {
     const val BASE_URL = "https://ohp6vrr7xd.execute-api.ca-central-1.amazonaws.com/dev/api/v1/"
+
+    const val MODERATION_STATUS_PENDING = "pending"
+    const val MODERATION_STATUS_VALID = "valid"
+    const val MODERATION_STATUS_REJECTED = "rejected"
 }

--- a/app/src/main/java/app/vdh/org/vdhapp/core/consts/PrefConst.kt
+++ b/app/src/main/java/app/vdh/org/vdhapp/core/consts/PrefConst.kt
@@ -7,4 +7,6 @@ object PrefConst {
     const val HOURS_SORT_PREFS_KEY = "hours_sort_prefs_key"
 
     const val HOURS_SORT_DEFAULT_VALUE = 2
+    const val MIN_HOUR = 1
+    const val MAX_HOUR = 24
 }

--- a/app/src/main/java/app/vdh/org/vdhapp/core/di/DiModules.kt
+++ b/app/src/main/java/app/vdh/org/vdhapp/core/di/DiModules.kt
@@ -15,12 +15,16 @@ import app.vdh.org.vdhapp.feature.report.data.map.repository.BicyclePathReposito
 import app.vdh.org.vdhapp.feature.report.domain.map.repository.BicyclePathRepository
 import app.vdh.org.vdhapp.feature.report.domain.map.usecase.GetBicyclePathUseCase
 import app.vdh.org.vdhapp.feature.report.domain.map.usecase.GetReportListUseCase
+import app.vdh.org.vdhapp.feature.report.domain.map.usecase.SyncReportListUseCase
+import app.vdh.org.vdhapp.feature.report.domain.moderation.usecase.GetReportByModerationStatusUseCase
+import app.vdh.org.vdhapp.feature.report.domain.moderation.usecase.UpdateModerationStatusUseCase
 import app.vdh.org.vdhapp.feature.report.domain.reporting.usecase.DeleteReportUseCase
 import app.vdh.org.vdhapp.feature.report.domain.reporting.usecase.SaveReportUseCase
 import app.vdh.org.vdhapp.feature.report.presentation.map.viewmodel.HoursFilterViewModel
 import app.vdh.org.vdhapp.feature.report.presentation.map.viewmodel.ReportMapViewModel
 import app.vdh.org.vdhapp.feature.report.presentation.reporting.viewmodel.ReportingViewModel
 import app.vdh.org.vdhapp.feature.report.presentation.map.viewmodel.StatusFilterViewModel
+import app.vdh.org.vdhapp.feature.report.presentation.moderation.viewmodel.ReportModerationViewModel
 import com.jakewharton.retrofit2.adapter.kotlin.coroutines.CoroutineCallAdapterFactory
 import org.koin.android.ext.koin.androidApplication
 import org.koin.android.viewmodel.ext.koin.viewModel
@@ -63,11 +67,15 @@ val appModule = module {
     factory { GetBicyclePathUseCase(get()) }
     factory { SaveReportUseCase(get(), androidApplication().applicationContext) }
     factory { DeleteReportUseCase(get()) }
+    factory { GetReportByModerationStatusUseCase(get()) }
+    factory { SyncReportListUseCase(get()) }
+    factory { UpdateModerationStatusUseCase(get()) }
 
     viewModel { ReportingViewModel(androidApplication(), get(), get()) }
-    viewModel { ReportMapViewModel(get(), get()) }
+    viewModel { ReportMapViewModel(get(), get(), get()) }
     viewModel { StatusFilterViewModel(androidApplication()) }
     viewModel { HoursFilterViewModel(androidApplication()) }
+    viewModel { ReportModerationViewModel(get(), get(), get()) }
 }
 
 private fun buildBaseRetrofit(): Retrofit {

--- a/app/src/main/java/app/vdh/org/vdhapp/core/extenstion/ActivityExtension.kt
+++ b/app/src/main/java/app/vdh/org/vdhapp/core/extenstion/ActivityExtension.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.Fragment
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 
 fun <T> Activity.navigateTo(klass: Class<T>, data: Bundle? = null) {
@@ -11,7 +12,15 @@ fun <T> Activity.navigateTo(klass: Class<T>, data: Bundle? = null) {
     data?.let {
         intent.putExtras(data)
     }
-    this.startActivity(intent)
+    startActivity(intent)
+}
+
+fun <T> Fragment.navigateTo(klass: Class<T>, data: Bundle? = null) {
+    val intent = Intent(context, klass)
+    data?.let {
+        intent.putExtras(data)
+    }
+    startActivity(intent)
 }
 
 fun <T : BottomSheetDialogFragment> AppCompatActivity.openBottomDialogFragment(fragment: T, tag: String) {

--- a/app/src/main/java/app/vdh/org/vdhapp/core/extenstion/TimeExtensions.kt
+++ b/app/src/main/java/app/vdh/org/vdhapp/core/extenstion/TimeExtensions.kt
@@ -1,0 +1,5 @@
+package app.vdh.org.vdhapp.core.extenstion
+
+import java.util.concurrent.TimeUnit
+
+fun Int.toMillisecondFromNow() = System.currentTimeMillis() - TimeUnit.HOURS.toMillis(toLong())

--- a/app/src/main/java/app/vdh/org/vdhapp/feature/report/data/common/local/AppDatabase.kt
+++ b/app/src/main/java/app/vdh/org/vdhapp/feature/report/data/common/local/AppDatabase.kt
@@ -12,7 +12,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlin.coroutines.CoroutineContext
 
-@Database(entities = [ReportEntity::class], version = 7, exportSchema = false)
+@Database(entities = [ReportEntity::class], version = 8, exportSchema = false)
 @TypeConverters(Converters::class)
 abstract class AppDatabase : RoomDatabase(), CoroutineScope {
 

--- a/app/src/main/java/app/vdh/org/vdhapp/feature/report/data/common/local/ReportDao.kt
+++ b/app/src/main/java/app/vdh/org/vdhapp/feature/report/data/common/local/ReportDao.kt
@@ -6,6 +6,7 @@ import androidx.room.Delete
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
+import app.vdh.org.vdhapp.core.consts.ApiConst
 import app.vdh.org.vdhapp.feature.report.data.common.local.entity.ReportEntity
 import app.vdh.org.vdhapp.feature.report.domain.common.model.Status
 
@@ -18,12 +19,27 @@ interface ReportDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertReportList(reportEntityList: List<ReportEntity>): List<Long>
 
-    @Query("SELECT * FROM reportentity WHERE timestamp >= :fromTimeStamp")
-    fun getAllReports(fromTimeStamp: Long): LiveData<List<ReportEntity>>
+    @Query("SELECT * FROM reportentity WHERE timestamp >= :fromTimeStamp AND (deviceId == :deviceId OR moderationStatus == :moderationStatus)")
+    fun getAllValidOrDeviceOwnerReports(
+            fromTimeStamp: Long,
+            deviceId: String,
+            moderationStatus: String = ApiConst.MODERATION_STATUS_VALID
+    ): LiveData<List<ReportEntity>>
 
-    @Query("SELECT * FROM reportentity WHERE status == :filterStatus AND timestamp >= :fromTimeStamp")
-    fun getReports(filterStatus: Status, fromTimeStamp: Long): LiveData<List<ReportEntity>>
+    @Query("SELECT * FROM reportentity WHERE (status == :filterStatus AND timestamp >= :fromTimeStamp) AND (deviceId == :deviceId OR moderationStatus == :moderationStatus)")
+    fun getValidOrDeviceOwnerReports(
+            filterStatus: Status,
+            fromTimeStamp: Long,
+            deviceId: String,
+            moderationStatus: String = ApiConst.MODERATION_STATUS_VALID
+    ): LiveData<List<ReportEntity>>
+
+    @Query("SELECT * FROM reportentity WHERE timestamp >= :fromTimeStamp AND moderationStatus == :moderationStatus ORDER BY timestamp DESC")
+    fun getReportsByModerationStatus(fromTimeStamp: Long, moderationStatus: String): LiveData<List<ReportEntity>>
 
     @Delete
     suspend fun deleteReport(reportEntity: ReportEntity)
+
+    @Query("UPDATE ReportEntity SET moderationStatus = :reportStatus WHERE serverId = :reportId")
+    suspend fun updateReport(reportId: String, reportStatus: String)
 }

--- a/app/src/main/java/app/vdh/org/vdhapp/feature/report/data/common/local/entity/ReportEntity.kt
+++ b/app/src/main/java/app/vdh/org/vdhapp/feature/report/data/common/local/entity/ReportEntity.kt
@@ -21,7 +21,8 @@ data class ReportEntity(
     val photoPath: String? = null,
     var comment: String? = null,
     val status: Status? = null,
-    val serverId: String? = null
+    val serverId: String? = null,
+    val moderationStatus: String? = null
 ) : Parcelable {
 
     companion object {
@@ -39,7 +40,8 @@ data class ReportEntity(
                 position = position,
                 sentToSever = sentToSever,
                 serverId = serverId,
-                timestamp = timestamp
+                timestamp = timestamp,
+                moderationStatus = moderationStatus
         )
     }
 }

--- a/app/src/main/java/app/vdh/org/vdhapp/feature/report/data/common/remote/ObservationApiClient.kt
+++ b/app/src/main/java/app/vdh/org/vdhapp/feature/report/data/common/remote/ObservationApiClient.kt
@@ -1,6 +1,7 @@
 package app.vdh.org.vdhapp.feature.report.data.common.remote
 
 import app.vdh.org.vdhapp.core.helpers.CallResult
+import app.vdh.org.vdhapp.feature.report.data.common.remote.dto.ModerationStatus
 import app.vdh.org.vdhapp.feature.report.data.common.remote.dto.ObservationDto
 import app.vdh.org.vdhapp.feature.report.data.common.remote.dto.ObservationListDto
 import okhttp3.ResponseBody
@@ -12,4 +13,6 @@ interface ObservationApiClient {
     suspend fun getObservations(): CallResult<ObservationListDto>
 
     suspend fun removeObservation(observationId: String): CallResult<ResponseBody>
+
+    suspend fun updateObservationModerationStatus(observationId: String, moderationStatus: ModerationStatus): CallResult<ObservationDto>
 }

--- a/app/src/main/java/app/vdh/org/vdhapp/feature/report/data/common/remote/ObservationApiClientImpl.kt
+++ b/app/src/main/java/app/vdh/org/vdhapp/feature/report/data/common/remote/ObservationApiClientImpl.kt
@@ -3,6 +3,7 @@ package app.vdh.org.vdhapp.feature.report.data.common.remote
 import android.util.Log
 import app.vdh.org.vdhapp.core.helpers.CallResult
 import app.vdh.org.vdhapp.core.helpers.safeCall
+import app.vdh.org.vdhapp.feature.report.data.common.remote.dto.ModerationStatus
 import app.vdh.org.vdhapp.feature.report.data.common.remote.dto.ObservationDto
 import app.vdh.org.vdhapp.feature.report.data.common.remote.dto.ObservationListDto
 import okhttp3.ResponseBody
@@ -46,5 +47,17 @@ class ObservationApiClientImpl(private val client: RetrofitClient) : Observation
                 CallResult.Error(Exception("Error occurred when removing reports ${response.errorBody()}"))
             }
         }, errorMessage = "Unable to remove observation")
+    }
+
+    override suspend fun updateObservationModerationStatus(observationId: String, moderationStatus: ModerationStatus): CallResult<ObservationDto> {
+        return safeCall({
+            val response = client.updateObservationStatusAsync(observationId, moderationStatus).await()
+            val responseBody = response.body()
+            if (response.isSuccessful && responseBody != null) {
+                CallResult.Success(responseBody)
+            } else {
+                CallResult.Error(Exception("Error occurred when updating report status ${response.errorBody()}"))
+            }
+        }, errorMessage = "Unable to update report status")
     }
 }

--- a/app/src/main/java/app/vdh/org/vdhapp/feature/report/data/common/remote/RetrofitClient.kt
+++ b/app/src/main/java/app/vdh/org/vdhapp/feature/report/data/common/remote/RetrofitClient.kt
@@ -1,5 +1,6 @@
 package app.vdh.org.vdhapp.feature.report.data.common.remote
 
+import app.vdh.org.vdhapp.feature.report.data.common.remote.dto.ModerationStatus
 import app.vdh.org.vdhapp.feature.report.data.common.remote.dto.ObservationDto
 import app.vdh.org.vdhapp.feature.report.data.common.remote.dto.ObservationListDto
 import app.vdh.org.vdhapp.feature.report.domain.map.model.BoundingBoxQueryParameter
@@ -13,6 +14,7 @@ import retrofit2.http.GET
 import retrofit2.http.POST
 import retrofit2.http.Query
 import retrofit2.http.DELETE
+import retrofit2.http.PUT
 import retrofit2.http.Path
 
 interface RetrofitClient {
@@ -30,6 +32,9 @@ interface RetrofitClient {
 
     @DELETE("observations/{id}")
     fun deleteObservationAsync(@Path("id") id: String): Deferred<Response<ResponseBody>>
+
+    @PUT("observations/status")
+    fun updateObservationStatusAsync(@Path("id") id: String, @Body moderationStatus: ModerationStatus): Deferred<Response<ObservationDto>>
 
     @GET("bicycle-paths")
     fun getBicyclePathsAsync(

--- a/app/src/main/java/app/vdh/org/vdhapp/feature/report/data/common/remote/dto/ModerationStatus.kt
+++ b/app/src/main/java/app/vdh/org/vdhapp/feature/report/data/common/remote/dto/ModerationStatus.kt
@@ -1,0 +1,7 @@
+package app.vdh.org.vdhapp.feature.report.data.common.remote.dto
+
+import com.google.gson.annotations.SerializedName
+
+data class ModerationStatus(
+    @SerializedName("status") val adminStatus: String
+)

--- a/app/src/main/java/app/vdh/org/vdhapp/feature/report/data/common/remote/dto/ObservationDto.kt
+++ b/app/src/main/java/app/vdh/org/vdhapp/feature/report/data/common/remote/dto/ObservationDto.kt
@@ -12,7 +12,8 @@ data class ObservationDto(
     @SerializedName("assets") val assets: List<ImageAssetDto>?,
     @SerializedName("comment") val comment: String,
     @SerializedName("deviceId") val deviceId: String,
-    @SerializedName("id") val id: String? = null
+    @SerializedName("id") val id: String? = null,
+    @SerializedName("status") val moderationStatus: ModerationStatus? = null
 ) {
 
     override fun equals(other: Any?): Boolean {
@@ -28,6 +29,7 @@ data class ObservationDto(
         if (comment != other.comment) return false
         if (deviceId != other.deviceId) return false
         if (id != other.id) return false
+        if (moderationStatus != other.moderationStatus) return false
 
         return true
     }
@@ -40,6 +42,7 @@ data class ObservationDto(
         result = 31 * result + comment.hashCode()
         result = 31 * result + deviceId.hashCode()
         result = 31 * result + id.hashCode()
+        result = 31 * result + moderationStatus.hashCode()
         return result
     }
 
@@ -59,7 +62,8 @@ data class ObservationDto(
                 timestamp = timestamp * 1000,
                 photoPath = photoPath,
                 serverId = id,
-                sentToSever = true
+                sentToSever = true,
+                moderationStatus = moderationStatus?.adminStatus
         )
     }
 }

--- a/app/src/main/java/app/vdh/org/vdhapp/feature/report/data/common/repository/ReportRepositoryImpl.kt
+++ b/app/src/main/java/app/vdh/org/vdhapp/feature/report/data/common/repository/ReportRepositoryImpl.kt
@@ -3,6 +3,7 @@ package app.vdh.org.vdhapp.feature.report.data.common.repository
 import android.content.Context
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.map
+import app.vdh.org.vdhapp.core.extenstion.toMillisecondFromNow
 import app.vdh.org.vdhapp.core.helpers.CallResult
 import app.vdh.org.vdhapp.feature.report.data.common.local.ReportDao
 import app.vdh.org.vdhapp.feature.report.data.common.local.entity.ReportEntity
@@ -11,10 +12,11 @@ import app.vdh.org.vdhapp.feature.report.data.common.remote.dto.ObservationDto
 import app.vdh.org.vdhapp.feature.report.data.common.remote.dto.ObservationListDto
 import app.vdh.org.vdhapp.feature.report.data.common.remote.dto.toReportEntities
 import app.vdh.org.vdhapp.core.helpers.safeCall
+import app.vdh.org.vdhapp.feature.report.data.common.remote.dto.ModerationStatus
 import app.vdh.org.vdhapp.feature.report.domain.common.model.ReportModel
 import app.vdh.org.vdhapp.feature.report.domain.common.model.Status
 import app.vdh.org.vdhapp.feature.report.domain.common.repository.ReportRepository
-import java.util.concurrent.TimeUnit
+import app.vdh.org.vdhapp.feature.settings.presentation.extension.uniqueId
 
 class ReportRepositoryImpl(
     private val reportDao: ReportDao,
@@ -23,9 +25,30 @@ class ReportRepositoryImpl(
 ) : ReportRepository {
 
     override suspend fun getReports(hoursAgo: Int, status: Status?): LiveData<List<ReportModel>> {
-        val from = System.currentTimeMillis() - TimeUnit.HOURS.toMillis(hoursAgo.toLong())
-        syncReports()
-        return getReports(from, status).map { entities -> entities.map { it.toReportModel() } }
+        return getReports(hoursAgo.toMillisecondFromNow(), status)
+                .map { entities -> entities.map { it.toReportModel() } }
+    }
+
+    override suspend fun getReportsByModerationStatus(hoursAgo: Int, moderationStatus: String): LiveData<List<ReportModel>> {
+        return reportDao.getReportsByModerationStatus(hoursAgo.toMillisecondFromNow(), moderationStatus)
+                .map { entities -> entities.map { it.toReportModel() } }
+    }
+
+    override suspend fun syncReports(): CallResult<Int>? {
+        return when (val observationsResult = safeCall(call = { observationApiClient.getObservations() },
+                errorMessage = "Error occurred when getting observations")) {
+            is CallResult.Success -> {
+                when (val insertionResult = safeCall(call = { saveObservationList(observationsResult.data) },
+                        errorMessage = "Error occurred when saving observations")) {
+                    is CallResult.Success -> CallResult.Success(observationsResult.data.observationList.size)
+                    is CallResult.Error -> CallResult.Error(insertionResult.exception)
+                }
+            }
+
+            is CallResult.Error -> {
+                CallResult.Error(observationsResult.exception)
+            }
+        }
     }
 
     override suspend fun saveReport(report: ReportModel, saveRemotely: Boolean): Pair<CallResult<Long>, CallResult<ObservationDto>?> {
@@ -70,6 +93,17 @@ class ReportRepositoryImpl(
         return CallResult.Success(reportDao.deleteReport(report.toReportEntity()))
     }
 
+    override suspend fun updateReportModerationStatus(reportId: String, status: String): CallResult<ObservationDto> {
+        val result = safeCall(
+                call = { observationApiClient.updateObservationModerationStatus(reportId, ModerationStatus(status)) },
+                errorMessage = "Unable to update report"
+        )
+        if (result is CallResult.Success) {
+            reportDao.updateReport(reportId, status)
+        }
+        return result
+    }
+
     private suspend fun saveObservationList(observationListDto: ObservationListDto): CallResult<List<Long>> {
         val reports = observationListDto.observationList.toReportEntities()
         return CallResult.Success(reportDao.insertReportList(reports))
@@ -79,28 +113,11 @@ class ReportRepositoryImpl(
         return CallResult.Success(reportDao.insertReport(report))
     }
 
-    private suspend fun syncReports(): CallResult<Int>? {
-        return when (val observationsResult = safeCall(call = { observationApiClient.getObservations() },
-                errorMessage = "Error occurred when getting observations")) {
-            is CallResult.Success -> {
-                when (val insertionResult = safeCall(call = { saveObservationList(observationsResult.data) },
-                        errorMessage = "Error occurred when saving observations")) {
-                    is CallResult.Success -> CallResult.Success(observationsResult.data.observationList.size)
-                    is CallResult.Error -> CallResult.Error(insertionResult.exception)
-                }
-            }
-
-            is CallResult.Error -> {
-                CallResult.Error(observationsResult.exception)
-            }
-        }
-    }
-
     private fun getReports(from: Long, status: Status?): LiveData<List<ReportEntity>> {
         return if (status == null) {
-            reportDao.getAllReports(from)
+            reportDao.getAllValidOrDeviceOwnerReports(from, appContext.uniqueId())
         } else {
-            reportDao.getReports(status, from)
+            reportDao.getValidOrDeviceOwnerReports(status, from, appContext.uniqueId())
         }
     }
 }

--- a/app/src/main/java/app/vdh/org/vdhapp/feature/report/domain/common/model/ReportModel.kt
+++ b/app/src/main/java/app/vdh/org/vdhapp/feature/report/domain/common/model/ReportModel.kt
@@ -23,7 +23,8 @@ data class ReportModel(
     val photoPath: String? = null,
     var comment: String? = null,
     val status: Status? = null,
-    val serverId: String? = null
+    val serverId: String? = null,
+    val moderationStatus: String? = null
 ) : Parcelable {
 
     companion object {

--- a/app/src/main/java/app/vdh/org/vdhapp/feature/report/domain/common/repository/ReportRepository.kt
+++ b/app/src/main/java/app/vdh/org/vdhapp/feature/report/domain/common/repository/ReportRepository.kt
@@ -11,7 +11,13 @@ interface ReportRepository {
 
     suspend fun getReports(hoursAgo: Int = PrefConst.HOURS_SORT_DEFAULT_VALUE, status: Status?): LiveData<List<ReportModel>>
 
+    suspend fun getReportsByModerationStatus(hoursAgo: Int, moderationStatus: String): LiveData<List<ReportModel>>
+
+    suspend fun syncReports(): CallResult<Int>?
+
     suspend fun saveReport(report: ReportModel, saveRemotely: Boolean): Pair<CallResult<Long>, CallResult<ObservationDto>?>
 
     suspend fun deleteReport(report: ReportModel): CallResult<String>
+
+    suspend fun updateReportModerationStatus(reportId: String, status: String): CallResult<ObservationDto>
 }

--- a/app/src/main/java/app/vdh/org/vdhapp/feature/report/domain/map/usecase/SyncReportListUseCase.kt
+++ b/app/src/main/java/app/vdh/org/vdhapp/feature/report/domain/map/usecase/SyncReportListUseCase.kt
@@ -1,0 +1,10 @@
+package app.vdh.org.vdhapp.feature.report.domain.map.usecase
+
+import app.vdh.org.vdhapp.feature.report.domain.common.repository.ReportRepository
+
+class SyncReportListUseCase(private val repository: ReportRepository) {
+
+    suspend fun execute() {
+        repository.syncReports()
+    }
+}

--- a/app/src/main/java/app/vdh/org/vdhapp/feature/report/domain/moderation/usecase/GetReportByModerationStatusUseCase.kt
+++ b/app/src/main/java/app/vdh/org/vdhapp/feature/report/domain/moderation/usecase/GetReportByModerationStatusUseCase.kt
@@ -1,0 +1,12 @@
+package app.vdh.org.vdhapp.feature.report.domain.moderation.usecase
+
+import androidx.lifecycle.LiveData
+import app.vdh.org.vdhapp.feature.report.domain.common.model.ReportModel
+import app.vdh.org.vdhapp.feature.report.domain.common.repository.ReportRepository
+
+class GetReportByModerationStatusUseCase(private val repository: ReportRepository) {
+
+    suspend fun execute(hoursAgo: Int, moderationStatus: String): LiveData<List<ReportModel>> {
+        return repository.getReportsByModerationStatus(hoursAgo, moderationStatus)
+    }
+}

--- a/app/src/main/java/app/vdh/org/vdhapp/feature/report/domain/moderation/usecase/UpdateModerationStatusUseCase.kt
+++ b/app/src/main/java/app/vdh/org/vdhapp/feature/report/domain/moderation/usecase/UpdateModerationStatusUseCase.kt
@@ -1,0 +1,12 @@
+package app.vdh.org.vdhapp.feature.report.domain.moderation.usecase
+
+import app.vdh.org.vdhapp.core.helpers.CallResult
+import app.vdh.org.vdhapp.feature.report.data.common.remote.dto.ObservationDto
+import app.vdh.org.vdhapp.feature.report.domain.common.repository.ReportRepository
+
+class UpdateModerationStatusUseCase(val repository: ReportRepository) {
+
+    suspend fun execute(reportId: String, newStatus: String): CallResult<ObservationDto> {
+        return repository.updateReportModerationStatus(reportId, newStatus)
+    }
+}

--- a/app/src/main/java/app/vdh/org/vdhapp/feature/report/presentation/map/fragment/HourFilterDialogFragment.kt
+++ b/app/src/main/java/app/vdh/org/vdhapp/feature/report/presentation/map/fragment/HourFilterDialogFragment.kt
@@ -7,6 +7,7 @@ import android.view.ViewGroup
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.Observer
 import app.vdh.org.vdhapp.R
+import app.vdh.org.vdhapp.core.consts.PrefConst
 import app.vdh.org.vdhapp.core.consts.PrefConst.HOURS_SORT_PREFS_KEY
 import app.vdh.org.vdhapp.databinding.FragmentHoursFilterBinding
 import app.vdh.org.vdhapp.feature.report.presentation.map.viewmodel.HoursFilterViewModel
@@ -57,10 +58,10 @@ class HourFilterDialogFragment : BottomSheetDialogFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        report_filter_number_picker.minValue = 1
-        report_filter_number_picker.maxValue = 24
+        report_filter_number_picker.minValue = PrefConst.MIN_HOUR
+        report_filter_number_picker.maxValue = PrefConst.MAX_HOUR
         report_filter_number_picker.value = viewModel.currentHoursAgoFilter
-        report_filter_number_picker.displayedValues = Array(24) {
+        report_filter_number_picker.displayedValues = Array(PrefConst.MAX_HOUR) {
             val currentHour = it + 1
             "$currentHour ${resources.getQuantityString(R.plurals.hours, currentHour)}"
         }

--- a/app/src/main/java/app/vdh/org/vdhapp/feature/report/presentation/map/fragment/StatusFilterDialogFragment.kt
+++ b/app/src/main/java/app/vdh/org/vdhapp/feature/report/presentation/map/fragment/StatusFilterDialogFragment.kt
@@ -41,7 +41,7 @@ class StatusFilterDialogFragment : BottomSheetDialogFragment() {
         }
 
         binding.viewModel = viewModel
-        binding.setLifecycleOwner(this)
+        binding.lifecycleOwner = this
 
         viewModel.reportMapFilterViewAction.observe(viewLifecycleOwner, Observer { statusFilterEvent ->
             when (statusFilterEvent) {

--- a/app/src/main/java/app/vdh/org/vdhapp/feature/report/presentation/map/viewmodel/ReportMapViewModel.kt
+++ b/app/src/main/java/app/vdh/org/vdhapp/feature/report/presentation/map/viewmodel/ReportMapViewModel.kt
@@ -15,6 +15,7 @@ import app.vdh.org.vdhapp.feature.report.domain.map.model.BikePathNetwork
 import app.vdh.org.vdhapp.feature.report.domain.map.model.BoundingBoxQueryParameter
 import app.vdh.org.vdhapp.feature.report.domain.map.usecase.GetBicyclePathUseCase
 import app.vdh.org.vdhapp.feature.report.domain.map.usecase.GetReportListUseCase
+import app.vdh.org.vdhapp.feature.report.domain.map.usecase.SyncReportListUseCase
 import app.vdh.org.vdhapp.feature.report.presentation.map.action.ReportMapAction
 import app.vdh.org.vdhapp.feature.report.presentation.map.action.ReportMapFilterViewAction
 import app.vdh.org.vdhapp.feature.report.presentation.map.action.ReportMapViewAction
@@ -24,6 +25,7 @@ import kotlinx.coroutines.withContext
 
 class ReportMapViewModel(
     reportListUseCase: GetReportListUseCase,
+    syncReportUseCase: SyncReportListUseCase,
     private val bicyclePathUseCase: GetBicyclePathUseCase
 ) : ViewModel() {
 
@@ -39,6 +41,7 @@ class ReportMapViewModel(
                     status = currentFilterEvent.status,
                     hoursAgo = currentFilterEvent.hoursAgo
             ))
+            syncReportUseCase.execute()
         }
     }
 

--- a/app/src/main/java/app/vdh/org/vdhapp/feature/report/presentation/moderation/action/ReportModerationActions.kt
+++ b/app/src/main/java/app/vdh/org/vdhapp/feature/report/presentation/moderation/action/ReportModerationActions.kt
@@ -1,0 +1,12 @@
+package app.vdh.org.vdhapp.feature.report.presentation.moderation.action
+
+sealed class ReportModerationViewAction {
+
+    data class ChangeModerationStatusFilter(val status: String) : ReportModerationViewAction()
+    data class ChangeModerationStatus(val reportId: String, val reportPosition: Int, val newStatus: String) : ReportModerationViewAction()
+}
+
+sealed class ReportModerationAction {
+    data class ReportStatusUpdated(val reportPosition: Int) : ReportModerationAction()
+    object ReportStatusUpdateError : ReportModerationAction()
+}

--- a/app/src/main/java/app/vdh/org/vdhapp/feature/report/presentation/moderation/activity/ReportModerationActivity.kt
+++ b/app/src/main/java/app/vdh/org/vdhapp/feature/report/presentation/moderation/activity/ReportModerationActivity.kt
@@ -1,0 +1,83 @@
+package app.vdh.org.vdhapp.feature.report.presentation.moderation.activity
+
+import androidx.appcompat.app.AppCompatActivity
+import android.os.Bundle
+import android.view.Menu
+import android.view.MenuInflater
+import android.view.MenuItem
+import androidx.lifecycle.Observer
+import androidx.recyclerview.widget.LinearLayoutManager
+import app.vdh.org.vdhapp.R
+import app.vdh.org.vdhapp.core.consts.ApiConst
+import app.vdh.org.vdhapp.feature.report.presentation.moderation.action.ReportModerationAction
+import app.vdh.org.vdhapp.feature.report.presentation.moderation.action.ReportModerationViewAction
+import app.vdh.org.vdhapp.feature.report.presentation.moderation.recyclerview.ReportModerationAdapter
+import app.vdh.org.vdhapp.feature.report.presentation.moderation.viewmodel.ReportModerationViewModel
+import com.esafirm.imagepicker.view.GridSpacingItemDecoration
+import com.google.android.material.snackbar.Snackbar
+import kotlinx.android.synthetic.main.activity_report_moderation.*
+import org.koin.android.viewmodel.ext.android.viewModel
+
+class ReportModerationActivity : AppCompatActivity() {
+
+    private val viewModel: ReportModerationViewModel by viewModel()
+    private val adapter = ReportModerationAdapter { viewAction ->
+        viewModel.handleViewAction(viewAction)
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_report_moderation)
+        configureRecyclerView()
+
+        viewModel.reports.observe(this, Observer { reportUiModels ->
+            if (reportUiModels != null) {
+                adapter.updateReports(reportUiModels)
+            }
+        })
+
+        viewModel.action.observe(this, Observer {
+            it?.let {
+                handleAction(it)
+            }
+        })
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu?): Boolean {
+        val inflater: MenuInflater = menuInflater
+        inflater.inflate(R.menu.moderation_menu, menu)
+        return true
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+
+        when (item.itemId) {
+            R.id.menu_pending_reports ->
+                viewModel.handleViewAction(ReportModerationViewAction.ChangeModerationStatusFilter(ApiConst.MODERATION_STATUS_PENDING))
+            R.id.menu_valid_reports ->
+                viewModel.handleViewAction(ReportModerationViewAction.ChangeModerationStatusFilter(ApiConst.MODERATION_STATUS_VALID))
+            R.id.menu_refused_reports ->
+                viewModel.handleViewAction(ReportModerationViewAction.ChangeModerationStatusFilter(ApiConst.MODERATION_STATUS_REJECTED))
+        }
+
+        return super.onOptionsItemSelected(item)
+    }
+
+    private fun handleAction(reportModerationAction: ReportModerationAction) {
+        when (reportModerationAction) {
+            is ReportModerationAction.ReportStatusUpdated -> {
+            }
+
+            is ReportModerationAction.ReportStatusUpdateError -> {
+                Snackbar.make(reportRecyclerView, R.string.update_report_error, Snackbar.LENGTH_SHORT).show()
+            }
+        }
+    }
+
+    private fun configureRecyclerView() {
+        reportRecyclerView.layoutManager = LinearLayoutManager(this, LinearLayoutManager.VERTICAL, false)
+        reportRecyclerView.setHasFixedSize(true)
+        reportRecyclerView.addItemDecoration(GridSpacingItemDecoration(1, resources.getDimensionPixelSize(R.dimen.medium_spacing), true))
+        reportRecyclerView.adapter = adapter
+    }
+}

--- a/app/src/main/java/app/vdh/org/vdhapp/feature/report/presentation/moderation/recyclerview/ReportModerationAdapter.kt
+++ b/app/src/main/java/app/vdh/org/vdhapp/feature/report/presentation/moderation/recyclerview/ReportModerationAdapter.kt
@@ -1,0 +1,32 @@
+package app.vdh.org.vdhapp.feature.report.presentation.moderation.recyclerview
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import app.vdh.org.vdhapp.R
+import app.vdh.org.vdhapp.feature.report.presentation.moderation.action.ReportModerationViewAction
+import app.vdh.org.vdhapp.feature.report.presentation.moderation.uimodel.ReportModerationUiModel
+
+class ReportModerationAdapter(
+    private val viewActionHandler: (ReportModerationViewAction) -> Unit
+) : RecyclerView.Adapter<ReportModerationViewHolder>() {
+
+    private val reports: MutableList<ReportModerationUiModel> = mutableListOf()
+
+    fun updateReports(newReports: List<ReportModerationUiModel>) {
+        reports.clear()
+        reports.addAll(newReports)
+        notifyDataSetChanged()
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ReportModerationViewHolder {
+        val view = LayoutInflater.from(parent.context).inflate(R.layout.view_report_item, parent, false)
+        return ReportModerationViewHolder(view, viewActionHandler)
+    }
+
+    override fun getItemCount(): Int = reports.count()
+
+    override fun onBindViewHolder(holder: ReportModerationViewHolder, position: Int) {
+        holder.onBind(reports[position])
+    }
+}

--- a/app/src/main/java/app/vdh/org/vdhapp/feature/report/presentation/moderation/recyclerview/ReportModerationViewHolder.kt
+++ b/app/src/main/java/app/vdh/org/vdhapp/feature/report/presentation/moderation/recyclerview/ReportModerationViewHolder.kt
@@ -1,0 +1,38 @@
+package app.vdh.org.vdhapp.feature.report.presentation.moderation.recyclerview
+
+import android.graphics.drawable.ColorDrawable
+import android.view.View
+import androidx.core.content.ContextCompat
+import androidx.recyclerview.widget.RecyclerView
+import app.vdh.org.vdhapp.R
+import app.vdh.org.vdhapp.core.consts.ApiConst
+import app.vdh.org.vdhapp.feature.report.presentation.moderation.action.ReportModerationViewAction
+import app.vdh.org.vdhapp.feature.report.presentation.moderation.uimodel.ReportModerationUiModel
+import kotlinx.android.synthetic.main.view_report_item.view.*
+
+class ReportModerationViewHolder(
+    view: View,
+    private val viewActionHandler: (ReportModerationViewAction) -> Unit
+) : RecyclerView.ViewHolder(view) {
+
+    fun onBind(reportUiModel: ReportModerationUiModel) {
+
+        itemView.reportStatus.setImageResource(reportUiModel.pathStatusIcon)
+        itemView.reportComment.text = reportUiModel.comment
+
+        when (reportUiModel.moderationStatus) {
+            ApiConst.MODERATION_STATUS_VALID -> itemView.reportModerationStatus.background = ColorDrawable(ContextCompat.getColor(itemView.context, R.color.green))
+            ApiConst.MODERATION_STATUS_PENDING -> itemView.reportModerationStatus.background = ColorDrawable(ContextCompat.getColor(itemView.context, R.color.orange))
+        }
+
+        itemView.acceptReportButton.visibility = if (reportUiModel.displayAcceptReport) View.VISIBLE else View.INVISIBLE
+        itemView.acceptReportButton.setOnClickListener {
+            viewActionHandler(ReportModerationViewAction.ChangeModerationStatus(reportUiModel.reportId, adapterPosition, ApiConst.MODERATION_STATUS_VALID))
+        }
+
+        itemView.refuseReportButton.visibility = if (reportUiModel.displayRejectReport) View.VISIBLE else View.INVISIBLE
+        itemView.refuseReportButton.setOnClickListener {
+            viewActionHandler(ReportModerationViewAction.ChangeModerationStatus(reportUiModel.reportId, adapterPosition, ApiConst.MODERATION_STATUS_REJECTED))
+        }
+    }
+}

--- a/app/src/main/java/app/vdh/org/vdhapp/feature/report/presentation/moderation/uimodel/ReportModerationUiModel.kt
+++ b/app/src/main/java/app/vdh/org/vdhapp/feature/report/presentation/moderation/uimodel/ReportModerationUiModel.kt
@@ -1,0 +1,26 @@
+package app.vdh.org.vdhapp.feature.report.presentation.moderation.uimodel
+
+import androidx.annotation.DrawableRes
+import app.vdh.org.vdhapp.core.consts.ApiConst
+import app.vdh.org.vdhapp.feature.report.domain.common.model.ReportModel
+
+data class ReportModerationUiModel(
+    val reportId: String,
+    @DrawableRes
+    val pathStatusIcon: Int,
+    val comment: String,
+    val moderationStatus: String,
+    val displayAcceptReport: Boolean,
+    val displayRejectReport: Boolean
+)
+
+fun ReportModel.toReportModerationUiModel(statusFilter: String): ReportModerationUiModel {
+    return ReportModerationUiModel(
+            reportId = serverId!!,
+            pathStatusIcon = status?.iconRes!!,
+            moderationStatus = moderationStatus!!,
+            comment = comment!!,
+            displayAcceptReport = statusFilter == ApiConst.MODERATION_STATUS_PENDING || statusFilter == ApiConst.MODERATION_STATUS_REJECTED,
+            displayRejectReport = statusFilter == ApiConst.MODERATION_STATUS_PENDING || statusFilter == ApiConst.MODERATION_STATUS_VALID
+    )
+}

--- a/app/src/main/java/app/vdh/org/vdhapp/feature/report/presentation/moderation/viewmodel/ReportModerationViewModel.kt
+++ b/app/src/main/java/app/vdh/org/vdhapp/feature/report/presentation/moderation/viewmodel/ReportModerationViewModel.kt
@@ -1,0 +1,69 @@
+package app.vdh.org.vdhapp.feature.report.presentation.moderation.viewmodel
+
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.liveData
+import androidx.lifecycle.map
+import androidx.lifecycle.switchMap
+import androidx.lifecycle.viewModelScope
+import app.vdh.org.vdhapp.core.consts.ApiConst
+import app.vdh.org.vdhapp.core.consts.PrefConst
+import app.vdh.org.vdhapp.core.helpers.CallResult
+import app.vdh.org.vdhapp.core.helpers.SingleLiveEvent
+import app.vdh.org.vdhapp.feature.report.domain.map.usecase.SyncReportListUseCase
+import app.vdh.org.vdhapp.feature.report.domain.moderation.usecase.GetReportByModerationStatusUseCase
+import app.vdh.org.vdhapp.feature.report.domain.moderation.usecase.UpdateModerationStatusUseCase
+import app.vdh.org.vdhapp.feature.report.presentation.moderation.action.ReportModerationAction
+import app.vdh.org.vdhapp.feature.report.presentation.moderation.action.ReportModerationViewAction
+import app.vdh.org.vdhapp.feature.report.presentation.moderation.uimodel.toReportModerationUiModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+class ReportModerationViewModel(
+    private val reportToModerateUseCase: GetReportByModerationStatusUseCase,
+    private val syncReportUseCase: SyncReportListUseCase,
+    private val updateModerationStatusUseCase: UpdateModerationStatusUseCase
+) : ViewModel() {
+
+    val action = SingleLiveEvent<ReportModerationAction>()
+    private val filter = MutableLiveData<String>()
+
+    init {
+        filter.postValue(ApiConst.MODERATION_STATUS_PENDING)
+    }
+
+    val reports = filter.switchMap { selectedFilter ->
+        liveData(context = viewModelScope.coroutineContext + Dispatchers.Main) {
+            val uiModels = reportToModerateUseCase.execute(PrefConst.MAX_HOUR, selectedFilter).map { reports ->
+                reports.map { it.toReportModerationUiModel(selectedFilter) }
+            }
+            emitSource(uiModels)
+            syncReportUseCase.execute()
+        }
+    }
+
+    fun handleViewAction(viewAction: ReportModerationViewAction) {
+        when (viewAction) {
+            is ReportModerationViewAction.ChangeModerationStatusFilter -> {
+                filter.postValue(viewAction.status)
+            }
+            is ReportModerationViewAction.ChangeModerationStatus -> {
+
+                viewModelScope.launch(viewModelScope.coroutineContext + Dispatchers.Default) {
+                    val result = updateModerationStatusUseCase.execute(viewAction.reportId, viewAction.newStatus)
+                    withContext(Dispatchers.Main) {
+                        when (result) {
+                            is CallResult.Success -> {
+                                action.postValue(ReportModerationAction.ReportStatusUpdated(viewAction.reportPosition))
+                            }
+                            is CallResult.Error -> {
+                                action.postValue(ReportModerationAction.ReportStatusUpdateError)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/app/vdh/org/vdhapp/feature/settings/presentation/fragment/SettingsFragment.kt
+++ b/app/src/main/java/app/vdh/org/vdhapp/feature/settings/presentation/fragment/SettingsFragment.kt
@@ -9,7 +9,10 @@ import androidx.preference.PreferenceCategory
 import androidx.preference.PreferenceFragmentCompat
 import app.vdh.org.vdhapp.BuildConfig
 import app.vdh.org.vdhapp.R
+import app.vdh.org.vdhapp.core.extenstion.navigateTo
 import app.vdh.org.vdhapp.feature.report.data.common.remote.mock.RetrofitMockClient
+import app.vdh.org.vdhapp.feature.report.presentation.moderation.activity.ReportModerationActivity
+import app.vdh.org.vdhapp.feature.settings.presentation.preferences.TitleSubtitlePreference
 import org.koin.android.ext.android.inject
 
 class SettingsFragment : PreferenceFragmentCompat() {
@@ -21,6 +24,10 @@ class SettingsFragment : PreferenceFragmentCompat() {
         findPreference<PreferenceCategory>(getString(R.string.pref_key_debug_category))?.isVisible = BuildConfig.isMockDataEnabled
         findPreference<Preference>(getString(R.string.pref_key_mock_data))?.setOnPreferenceClickListener {
             retrofitMockClient.generateMockData()
+            true
+        }
+        findPreference<TitleSubtitlePreference>(getString(R.string.pref_key_admin))?.setOnPreferenceClickListener {
+            navigateTo(ReportModerationActivity::class.java)
             true
         }
     }

--- a/app/src/main/res/layout/activity_report_moderation.xml
+++ b/app/src/main/res/layout/activity_report_moderation.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".feature.report.presentation.moderation.activity.ReportModerationActivity">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/reportRecyclerView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"/>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/view_report_item.xml
+++ b/app/src/main/res/layout/view_report_item.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<androidx.cardview.widget.CardView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="110dp"
+    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <ImageView
+            android:id="@+id/reportStatus"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            tools:src="@drawable/ic_snowy_on"
+            android:layout_marginStart="@dimen/medium_spacing"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toTopOf="@id/acceptReportButton"
+            app:layout_constraintStart_toStartOf="parent"/>
+
+        <TextView
+            android:id="@+id/reportComment"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/medium_spacing"
+            android:layout_marginEnd="@dimen/small_spacing"
+            android:maxLines="2"
+            android:ellipsize="end"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toTopOf="@id/acceptReportButton"
+            app:layout_constraintStart_toEndOf="@id/reportStatus"
+            app:layout_constraintEnd_toEndOf="parent"
+            tools:text="This is not a good road This is not a good road This is not a good road
+        This is not a good road This is not a good road This is not a good road This is not a good road "/>
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/acceptReportButton"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:text="@string/accept_report"
+            android:backgroundTint="@color/green"
+            android:layout_marginStart="@dimen/big_spacing"
+            android:layout_marginEnd="@dimen/medium_spacing"
+            app:layout_constraintTop_toBottomOf="@id/reportComment"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toStartOf="@id/refuseReportButton"
+            app:layout_constraintBottom_toBottomOf="parent"/>
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/refuseReportButton"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:text="@string/refuse_report"
+            android:backgroundTint="@color/red"
+            android:layout_marginStart="@dimen/medium_spacing"
+            android:layout_marginEnd="@dimen/big_spacing"
+            app:layout_constraintTop_toBottomOf="@id/reportComment"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/acceptReportButton"
+            app:layout_constraintBottom_toBottomOf="parent"/>
+
+        <View
+            android:id="@+id/reportModerationStatus"
+            android:layout_width="match_parent"
+            android:layout_height="@dimen/small_spacing"
+            android:background="@color/colorAccent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"/>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</androidx.cardview.widget.CardView>
+

--- a/app/src/main/res/menu/moderation_menu.xml
+++ b/app/src/main/res/menu/moderation_menu.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item android:id="@+id/menu_pending_reports"
+        app:showAsAction="never"
+        android:title="@string/filter_pending_reports" />
+
+    <item android:id="@+id/menu_valid_reports"
+        app:showAsAction="never"
+        android:title="@string/filter_valid_reports" />
+
+    <item android:id="@+id/menu_refused_reports"
+        app:showAsAction="never"
+        android:title="@string/filter_refused_reports"/>
+</menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -66,4 +66,13 @@
     <string name="settings_ama_mail">mailto:ama.ville.marie@gmail.com</string>
     <string name="settings_ama_fb_page">https://www.facebook.com/groups/AMAVM/</string>
 
+    <string name="accept_report">Accepter</string>
+    <string name="refuse_report">Refuser</string>
+
+    <string name="filter_pending_reports">En attente</string>
+    <string name="filter_valid_reports">Valide</string>
+    <string name="filter_refused_reports">Refuse</string>
+
+    <string name="update_report_error">Impossible de mettre a jour le rapport</string>
+
 </resources>


### PR DESCRIPTION
- Add api endpoint to be able to update observation status 
- Add dao method to do the same locally 
- Add moderation screen that list all the report filtered by status
- If you accept or refuse a report the list and the map are updated
- UI / UX improvement are coming 
- Admin auth is coming 